### PR TITLE
Add GitHub Actions workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+*       @canonical/dotnet-maintainers

--- a/.github/workflows/dotnet-runtime-60.yaml
+++ b/.github/workflows/dotnet-runtime-60.yaml
@@ -1,0 +1,52 @@
+name: dotnet-runtime-60
+
+on:
+  push:
+    branches: main
+    paths:
+      - dotnet-runtime-60/**
+  pull_request:
+    branches: main
+
+env:
+  SNAP_NAME: dotnet-runtime-60
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      id: checkout
+    - uses: snapcore/action-build@v1
+      id: build
+      with:
+        path: ${{ env.SNAP_NAME }}
+    - uses: actions/upload-artifact@v4
+      id: upload-artifact
+      with:
+        name: ${{ env.SNAP_NAME }}
+        path: ${{ steps.build.outputs.snap }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ env.SNAP_NAME }}
+      - name: Gather filename
+        id: gather-filename
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
+          echo "SNAP_PATH_X64=${SNAP_FILE_NAME_X64}" >> "$GITHUB_OUTPUT"
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.gather-filename.outputs.SNAP_PATH_X64 }}
+          release: edge

--- a/.github/workflows/dotnet-runtime-70.yaml
+++ b/.github/workflows/dotnet-runtime-70.yaml
@@ -1,0 +1,52 @@
+name: dotnet-runtime-70
+
+on:
+  push:
+    branches: main
+    paths:
+      - dotnet-runtime-70/**
+  pull_request:
+    branches: main
+
+env:
+  SNAP_NAME: dotnet-runtime-70
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      id: checkout
+    - uses: snapcore/action-build@v1
+      id: build
+      with:
+        path: ${{ env.SNAP_NAME }}
+    - uses: actions/upload-artifact@v4
+      id: upload-artifact
+      with:
+        name: ${{ env.SNAP_NAME }}
+        path: ${{ steps.build.outputs.snap }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ env.SNAP_NAME }}
+      - name: Gather filename
+        id: gather-filename
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
+          echo "SNAP_PATH_X64=${SNAP_FILE_NAME_X64}" >> "$GITHUB_OUTPUT"
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.gather-filename.outputs.SNAP_PATH_X64 }}
+          release: edge

--- a/.github/workflows/dotnet-runtime-80.yaml
+++ b/.github/workflows/dotnet-runtime-80.yaml
@@ -1,0 +1,52 @@
+name: dotnet-runtime-80
+
+on:
+  push:
+    branches: main
+    paths:
+      - dotnet-runtime-80/**
+  pull_request:
+    branches: main
+
+env:
+  SNAP_NAME: dotnet-runtime-80
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      id: checkout
+    - uses: snapcore/action-build@v1
+      id: build
+      with:
+        path: ${{ env.SNAP_NAME }}
+    - uses: actions/upload-artifact@v4
+      id: upload-artifact
+      with:
+        name: ${{ env.SNAP_NAME }}
+        path: ${{ steps.build.outputs.snap }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ env.SNAP_NAME }}
+      - name: Gather filename
+        id: gather-filename
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
+          echo "SNAP_PATH_X64=${SNAP_FILE_NAME_X64}" >> "$GITHUB_OUTPUT"
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.gather-filename.outputs.SNAP_PATH_X64 }}
+          release: edge

--- a/.github/workflows/dotnet-sdk-60.yaml
+++ b/.github/workflows/dotnet-sdk-60.yaml
@@ -1,0 +1,65 @@
+name: dotnet-sdk-60
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+env:
+  SNAP_NAME: dotnet-sdk-60
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+      id: checkout
+    - id: prepare-sha
+      run: git show -s --format=%h > ${SNAP_NAME}/GIT_SHA
+    - uses: snapcore/action-build@v1
+      id: build
+      with:
+        path: ${{ env.SNAP_NAME }}
+    - id: get-arch
+      run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
+    - uses: actions/upload-artifact@v4
+      id: upload-artifact
+      with:
+        # e.g. dotnet-sdk-60-amd64
+        name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
+        path: ${{ steps.build.outputs.snap }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' }}
+    strategy:
+      matrix:
+        artifact-name:
+          - dotnet-sdk-60-amd64
+          - dotnet-sdk-60-arm64
+    steps:
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ matrix.artifact-name }}
+      - name: Gather filename
+        id: gather-filename
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          echo "SNAP_PATH=${SNAP_FILE_NAME}" >> "$GITHUB_OUTPUT"
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.gather-filename.outputs.SNAP_PATH }}
+          release: edge

--- a/.github/workflows/dotnet-sdk-80.yaml
+++ b/.github/workflows/dotnet-sdk-80.yaml
@@ -1,0 +1,65 @@
+name: dotnet-sdk-80
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+env:
+  SNAP_NAME: dotnet-sdk-80
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+      id: checkout
+    - id: prepare-sha
+      run: git show -s --format=%h > ${SNAP_NAME}/GIT_SHA
+    - uses: snapcore/action-build@v1
+      id: build
+      with:
+        path: ${{ env.SNAP_NAME }}
+    - id: get-arch
+      run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
+    - uses: actions/upload-artifact@v4
+      id: upload-artifact
+      with:
+        # e.g. dotnet-sdk-80-amd64
+        name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
+        path: ${{ steps.build.outputs.snap }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' }}
+    strategy:
+      matrix:
+        artifact-name:
+          - dotnet-sdk-80-amd64
+          - dotnet-sdk-80-arm64
+    steps:
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ matrix.artifact-name }}
+      - name: Gather filename
+        id: gather-filename
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          echo "SNAP_PATH=${SNAP_FILE_NAME}" >> "$GITHUB_OUTPUT"
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.gather-filename.outputs.SNAP_PATH }}
+          release: edge

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ This repo tracks the snapcraft definitions of all .NET content snaps available i
 
 ### Runtimes
 
-|        Snap       |       Name       |                                    Link                                  |
-| ----------------- | ---------------- | ------------------------------------------------------------------------ |
-| dotnet-runtime-60 | .NET 6.0 Runtime | [snapcraft.io/dotnet-runtime-60](https://snapcraft.io/dotnet-runtime-60) |
-| dotnet-runtime-70 | .NET 7.0 Runtime | [snapcraft.io/dotnet-runtime-70](https://snapcraft.io/dotnet-runtime-70) |
-| dotnet-runtime-80 | .NET 8.0 Runtime | [snapcraft.io/dotnet-runtime-80](https://snapcraft.io/dotnet-runtime-80) |
+|        Snap       |       Name       |                                    Link                                  | Status |
+| ----------------- | ---------------- | ------------------------------------------------------------------------ | ------ |
+| dotnet-runtime-60 | .NET 6.0 Runtime | [![dotnet-runtime-60 in the Snap Store](https://snapcraft.io/dotnet-runtime-60/badge.svg)](https://snapcraft.io/dotnet-runtime-60) | [![dotnet-runtime-60](https://github.com/canonical/dotnet-content-snaps/actions/workflows/dotnet-runtime-60.yaml/badge.svg)](https://github.com/canonical/dotnet-content-snaps/actions/workflows/dotnet-runtime-60.yaml) |
+| dotnet-runtime-70 | .NET 7.0 Runtime | [![dotnet-runtime-70 in the Snap Store](https://snapcraft.io/dotnet-runtime-70/badge.svg)](https://snapcraft.io/dotnet-runtime-60) | [![dotnet-runtime-70](https://github.com/canonical/dotnet-content-snaps/actions/workflows/dotnet-runtime-70.yaml/badge.svg)](https://github.com/canonical/dotnet-content-snaps/actions/workflows/dotnet-runtime-70.yaml) |
+| dotnet-runtime-80 | .NET 8.0 Runtime | [![dotnet-runtime-80 in the Snap Store](https://snapcraft.io/dotnet-runtime-80/badge.svg)](https://snapcraft.io/dotnet-runtime-60) | [![dotnet-runtime-80](https://github.com/canonical/dotnet-content-snaps/actions/workflows/dotnet-runtime-80.yaml/badge.svg)](https://github.com/canonical/dotnet-content-snaps/actions/workflows/dotnet-runtime-80.yaml) |
 
 ### SDKs
 
 > [!CAUTION]
 > The SDK content snaps are still under development, which means that breaking changes might be released without further notice.
 
-|        Snap       |       Name       |                                Link                              |
-| ----------------- | ---------------- | ---------------------------------------------------------------- |
-| dotnet-sdk-60     | .NET 6.0 SDK     | [snapcraft.io/dotnet-sdk-60](https://snapcraft.io/dotnet-sdk-60) |
-| dotnet-sdk-80     | .NET 8.0 SDK     | [snapcraft.io/dotnet-sdk-80](https://snapcraft.io/dotnet-sdk-80) |
+|        Snap       |       Name       |                                Link                              | Status |
+| ----------------- | ---------------- | ---------------------------------------------------------------- | ------ |
+| dotnet-sdk-60     | .NET 6.0 SDK     | [![dotnet-sdk-60 in the Snap Store](https://snapcraft.io/dotnet-sdk-60/badge.svg)](https://snapcraft.io/dotnet-runtime-60) | [![dotnet-sdk-60](https://github.com/canonical/dotnet-content-snaps/actions/workflows/dotnet-sdk-60.yaml/badge.svg)](https://github.com/canonical/dotnet-content-snaps/actions/workflows/dotnet-sdk-60.yaml) |
+| dotnet-sdk-80     | .NET 8.0 SDK     | [![dotnet-sdk-80 in the Snap Store](https://snapcraft.io/dotnet-sdk-80/badge.svg)](https://snapcraft.io/dotnet-runtime-60) | [![dotnet-sdk-80](https://github.com/canonical/dotnet-content-snaps/actions/workflows/dotnet-sdk-80.yaml/badge.svg)](https://github.com/canonical/dotnet-content-snaps/actions/workflows/dotnet-sdk-80.yaml) |

--- a/dotnet-sdk-60/snapcraft.yaml
+++ b/dotnet-sdk-60/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: dotnet-sdk-60
 base: core22
-version: 6.0.128
+adopt-info: dotnet-sdk
 summary: .NET 6 SDK
 description: |
   The .NET SDK is a set of libraries and tools that developers use to create
@@ -8,6 +8,12 @@ description: |
 
 grade: stable
 confinement: strict
+
+architectures:
+  - build-on: [amd64]
+    build-for: [amd64]
+  - build-on: [arm64]
+    build-for: [arm64]
 
 slots:
   dotnet-sdk:
@@ -20,12 +26,30 @@ slots:
 parts:
   dotnet-sdk:
     plugin: nil
+    source: .
     stage-packages:
       - dotnet-sdk-6.0
+    override-stage: |
+      craftctl default
+      
+      if [ "${CRAFT_ARCH_BUILD_FOR}" = "amd64" ]; then
+        DOTNET_SDK_VERSION=$(LD_LIBRARY_PATH=${CRAFT_STAGE}/usr/lib/x86_64-linux-gnu ${CRAFT_STAGE}/usr/lib/dotnet/dotnet --version)
+      elif [ "${CRAFT_ARCH_BUILD_FOR}" = "arm64" ]; then
+        DOTNET_SDK_VERSION=$(LD_LIBRARY_PATH=${CRAFT_STAGE}/usr/lib/aarch64-linux-gnu ${CRAFT_STAGE}/usr/lib/dotnet/dotnet --version)
+      else
+        echo "Unknown architecture (${CRAFT_ARCH_BUILD_FOR})"
+        exit 1
+      fi
+
+      if [ -f ${CRAFT_PART_SRC}/GIT_SHA ]; then
+        craftctl set version="${DOTNET_SDK_VERSION}+git.$(cat ${CRAFT_PART_SRC}/GIT_SHA)"
+      else
+        craftctl set version="${DOTNET_SDK_VERSION}"
+      fi
 
 lint:
   ignore:
     - library:
-      - usr/lib/x86_64-linux-gnu/libicu*
-      - usr/lib/x86_64-linux-gnu/liblttng-ust-*
-      - usr/lib/x86_64-linux-gnu/libunwind-*
+      - usr/lib/**/libicu*
+      - usr/lib/**/liblttng-ust-*
+      - usr/lib/**/libunwind-*

--- a/dotnet-sdk-80/snapcraft.yaml
+++ b/dotnet-sdk-80/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: dotnet-sdk-80
 base: core22
-version: 8.0.105
+adopt-info: dotnet-sdk
 summary: .NET 8 SDK
 description: |
   The .NET SDK is a set of libraries and tools that developers use to create
@@ -8,6 +8,12 @@ description: |
 
 grade: stable
 confinement: strict
+
+architectures:
+  - build-on: [amd64]
+    build-for: [amd64]
+  - build-on: [arm64]
+    build-for: [arm64]
 
 slots:
   dotnet-sdk:
@@ -20,11 +26,30 @@ slots:
 parts:
   dotnet-sdk:
     plugin: nil
+    source: .
     stage-packages:
       - dotnet-sdk-8.0
+    override-stage: |
+      craftctl default
+
+      if [ "${CRAFT_ARCH_BUILD_FOR}" = "amd64" ]; then
+        DOTNET_SDK_VERSION=$(LD_LIBRARY_PATH=${CRAFT_STAGE}/usr/lib/x86_64-linux-gnu ${CRAFT_STAGE}/usr/lib/dotnet/dotnet --version)
+      elif [ "${CRAFT_ARCH_BUILD_FOR}" = "arm64" ]; then
+        DOTNET_SDK_VERSION=$(LD_LIBRARY_PATH=${CRAFT_STAGE}/usr/lib/aarch64-linux-gnu ${CRAFT_STAGE}/usr/lib/dotnet/dotnet --version)
+      else
+        echo "Unknown architecture (${CRAFT_ARCH_BUILD_FOR})"
+        exit 1
+      fi
+
+      if [ -f ${CRAFT_PART_SRC}/GIT_SHA ]; then
+        craftctl set version="${DOTNET_SDK_VERSION}+git.$(cat ${CRAFT_PART_SRC}/GIT_SHA)"
+      else
+        craftctl set version="${DOTNET_SDK_VERSION}"
+      fi
 
 lint:
   ignore:
     - library:
-      - usr/lib/x86_64-linux-gnu/libicu*
-      - usr/lib/x86_64-linux-gnu/liblttng-ust-*
+      - usr/lib/**/libicu*
+      - usr/lib/**/liblttng-ust-*
+      - usr/lib/**/libunwind-*


### PR DESCRIPTION
Adding GitHub Actions workflows to build and publish content snaps.

The workflows will build all snaps in the source tree in a Pull Request that targets `main`, as well as publish those snaps when pushing to `main`.
- SDK snaps will publish on every push made to `main`, since their `snapcraft.yaml` files don't have hard-coded version, so they won't change from one version to another. They are also being built for `amd64` and `arm64`.
- Runtime snaps will publish **only when a push includes changes to their own directories**. Since their `snapcraft.yaml` files HAVE hard-coded versions (at least, for the time being), this is a safe assumption considering that every new release will include a change in their respective yaml descriptors.

The SDK content snaps will include the short Git SHA in the version string, e.g. `8.0.105+git.abcd1234`. For the time being, as runtime content snaps are currently dumps from Microsoft's binaries, these won't include SHAs.

Also adding the CODEOWNERS file poiting to the [canonical/dotnet-maintainers](https://github.com/orgs/canonical/teams/dotnet-maintainers) team.