### PR TITLE
July updates and systemd-mount support

### DIFF
--- a/.github/workflows/dotnet-runtime-60.yaml
+++ b/.github/workflows/dotnet-runtime-60.yaml
@@ -7,6 +7,7 @@ on:
       - dotnet-runtime-60/**
   pull_request:
     branches: main
+  workflow_dispatch:
 
 env:
   SNAP_NAME: dotnet-runtime-60

--- a/.github/workflows/dotnet-runtime-70.yaml
+++ b/.github/workflows/dotnet-runtime-70.yaml
@@ -7,6 +7,7 @@ on:
       - dotnet-runtime-70/**
   pull_request:
     branches: main
+  workflow_dispatch:
 
 env:
   SNAP_NAME: dotnet-runtime-70

--- a/.github/workflows/dotnet-runtime-80.yaml
+++ b/.github/workflows/dotnet-runtime-80.yaml
@@ -7,6 +7,7 @@ on:
       - dotnet-runtime-80/**
   pull_request:
     branches: main
+  workflow_dispatch:
 
 env:
   SNAP_NAME: dotnet-runtime-80

--- a/.github/workflows/dotnet-sdk-60.yaml
+++ b/.github/workflows/dotnet-sdk-60.yaml
@@ -5,6 +5,7 @@ on:
     branches: main
   pull_request:
     branches: main
+  workflow_dispatch:
 
 env:
   SNAP_NAME: dotnet-sdk-60

--- a/.github/workflows/dotnet-sdk-80.yaml
+++ b/.github/workflows/dotnet-sdk-80.yaml
@@ -5,6 +5,7 @@ on:
     branches: main
   pull_request:
     branches: main
+  workflow_dispatch:
 
 env:
   SNAP_NAME: dotnet-sdk-80

--- a/dotnet-runtime-60/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
+++ b/dotnet-runtime-60/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-shared
+
+[Mount]
+What=/snap/{SNAP}/current/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-runtime-60/snapcraft.yaml
+++ b/dotnet-runtime-60/snapcraft.yaml
@@ -32,3 +32,23 @@ parts:
     stage-packages:
       - libicu66
       - liblttng-ust0
+  
+  mounts:
+    plugin: dump
+    after: 
+      - dotnet-runtime
+    source: .
+    override-build: |
+      RUNTIME_VERSION=$(ls ${SNAPCRAFT_STAGE}/shared/Microsoft.NETCore.App/ | grep 6.0)
+      
+      for file in mounts/*; do
+        sed -i "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/g" $file
+        sed -i "s/{SNAP}/$SNAPCRAFT_PROJECT_NAME/g" $file
+        if [[ "$file" == *"{RUNTIME_VERSION}"* ]]; then
+          new_file=$(echo "$file" | sed "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/")
+          mv "$file" "$new_file"
+          echo "Renamed '$file' to '$new_file'"
+        fi
+      done
+
+      snapcraftctl build

--- a/dotnet-runtime-60/snapcraft.yaml
+++ b/dotnet-runtime-60/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: dotnet-runtime-60
 base: core20
-version: 6.0.30
+version: 6.0.32
 summary: Cross-Platform .NET Core Runtime.
 description: |
   .NET Core runtimes and libraries which are optimized for running .NET Core apps in production. See https://dot.net/core.
@@ -27,8 +27,8 @@ slots:
 parts:
   dotnet-runtime:
     plugin: dump
-    source: https://download.visualstudio.microsoft.com/download/pr/a80ab89d-9f64-47b9-bba5-907a4cdaf457/c5714a6e605ef86293a5145d8ea72f39/dotnet-runtime-6.0.30-linux-x64.tar.gz
-    source-checksum: sha512/b43200ec3a8c74475f396becd21d22c6a78a6713585837707c2a84bbb869c7e551a05c4c1c1cdba8083baebdd09bc356de5d5a833b8bc84b83421d3ecfac71ca
+    source: https://download.visualstudio.microsoft.com/download/pr/37d9269f-d651-4248-beae-ccfbf4dc34fc/17809ba306015df6406cf4338b5cc576/dotnet-runtime-6.0.32-linux-x64.tar.gz
+    source-checksum: sha512/9babfe66f4a4261dd454f3220899af0a19532ab93575b581cec838f1c5f130d98b6fb1aaae5ee8e5b2e70deb55b619a0d55347f014ace72cb84b78d61faf0a59
     stage-packages:
       - libicu66
       - liblttng-ust0

--- a/dotnet-runtime-70/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
+++ b/dotnet-runtime-70/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-shared
+
+[Mount]
+What=/snap/{SNAP}/current/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-runtime-70/snapcraft.yaml
+++ b/dotnet-runtime-70/snapcraft.yaml
@@ -32,3 +32,23 @@ parts:
     stage-packages:
       - libicu66
       - liblttng-ust0
+
+  mounts:
+    plugin: dump
+    after: 
+      - dotnet-runtime
+    source: .
+    override-build: |
+      RUNTIME_VERSION=$(ls ${SNAPCRAFT_STAGE}/shared/Microsoft.NETCore.App/ | grep 7.0)
+      
+      for file in mounts/*; do
+        sed -i "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/g" $file
+        sed -i "s/{SNAP}/$SNAPCRAFT_PROJECT_NAME/g" $file
+        if [[ "$file" == *"{RUNTIME_VERSION}"* ]]; then
+          new_file=$(echo "$file" | sed "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/")
+          mv "$file" "$new_file"
+          echo "Renamed '$file' to '$new_file'"
+        fi
+      done
+
+      snapcraftctl build

--- a/dotnet-runtime-70/snapcraft.yaml
+++ b/dotnet-runtime-70/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: dotnet-runtime-70
 base: core20
-version: 7.0.19
+version: 7.0.20
 summary: Cross-Platform .NET Core Runtime.
 description: |
   .NET Core runtimes and libraries which are optimized for running .NET Core apps in production. See https://dot.net/core.
@@ -27,8 +27,8 @@ slots:
 parts:
   dotnet-runtime:
     plugin: dump
-    source: https://download.visualstudio.microsoft.com/download/pr/09ab2389-5bab-4d45-9a91-a56ff322e83c/2f8192a98b6887c7f12b0d2dc4a06247/dotnet-runtime-7.0.19-linux-x64.tar.gz
-    source-checksum: sha512/4e556c1437a58d2325e3eeb5a5c4b718599dff206af957a80490ef2945b1a2f5114d25b808b4c9ea233cc4eb2e5ce40932bb249e198319e97f3b5cc443612e6f
+    source: https://download.visualstudio.microsoft.com/download/pr/2c5981ff-0f0c-47ab-bff4-0ea4919b395b/cbfdfa7f35d133b0bdef87fa3830bfa0/dotnet-runtime-7.0.20-linux-x64.tar.gz
+    source-checksum: sha512/87855297338555a7b577d7e314e5dbf2c2350f8c867a489cd1e535634bad5c123a1871464d37fc9421837ff5d426c2eadecbe0f60bbf3fd32bc2461f47790a40
     stage-packages:
       - libicu66
       - liblttng-ust0

--- a/dotnet-runtime-80/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
+++ b/dotnet-runtime-80/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-shared
+
+[Mount]
+What=/snap/{SNAP}/current/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-runtime-80/snapcraft.yaml
+++ b/dotnet-runtime-80/snapcraft.yaml
@@ -32,3 +32,23 @@ parts:
     stage-packages:
       - libicu66
       - liblttng-ust0
+
+  mounts:
+    plugin: dump
+    after: 
+      - dotnet-runtime
+    source: .
+    override-build: |
+      RUNTIME_VERSION=$(ls ${SNAPCRAFT_STAGE}/shared/Microsoft.NETCore.App/ | grep 8.0)
+      
+      for file in mounts/*; do
+        sed -i "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/g" $file
+        sed -i "s/{SNAP}/$SNAPCRAFT_PROJECT_NAME/g" $file
+        if [[ "$file" == *"{RUNTIME_VERSION}"* ]]; then
+          new_file=$(echo "$file" | sed "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/")
+          mv "$file" "$new_file"
+          echo "Renamed '$file' to '$new_file'"
+        fi
+      done
+
+      snapcraftctl build

--- a/dotnet-runtime-80/snapcraft.yaml
+++ b/dotnet-runtime-80/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: dotnet-runtime-80
 base: core20
-version: 8.0.5
+version: 8.0.7
 summary: Cross-Platform .NET Core Runtime.
 description: |
   .NET Core runtimes and libraries which are optimized for running .NET Core apps in production. See https://dot.net/core.
@@ -27,8 +27,8 @@ slots:
 parts:
   dotnet-runtime:
     plugin: dump
-    source: https://download.visualstudio.microsoft.com/download/pr/baeb5da3-4b77-465b-8816-b29f0bc3e1a9/b04b17a2aae79e5f5635a3ceffbd4645/dotnet-runtime-8.0.5-linux-x64.tar.gz
-    source-checksum: sha512/3efff49feb2e11cb5ec08dcee4e1e8ad92a4d2516b721a98b55ef2ada231cad0c91fd20b71ab5e340047fc837bd02d143449dd32f4f95288f6f659fa6c790eaa
+    source: https://download.visualstudio.microsoft.com/download/pr/cf3418ca-0e14-4b76-b615-ac2f2497f8ec/2583028ea52460cb1534d929dc7970fe/dotnet-runtime-8.0.7-linux-x64.tar.gz
+    source-checksum: sha512/88e9ac34ad5ac76eec5499f2eb8d1aa35076518c842854ec1053953d34969c7bf1c5b2dbce245dbace3a18c3b8a4c79d2ef2d2ff105ce9d17cbbdbe813d8b16f
     stage-packages:
       - libicu66
       - liblttng-ust0

--- a/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-metadata-workloads-6.0.100.mount
+++ b/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-metadata-workloads-6.0.100.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-metadata
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/metadata/workloads/6.0.100
+Where=/var/snap/dotnet/common/dotnet/metadata/workloads/6.0.100
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.AspNetCore.App.Ref-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.AspNetCore.App.Ref-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-packs-aspnetcore
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/packs/Microsoft.AspNetCore.App.Ref/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/packs/Microsoft.AspNetCore.App.Ref/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.NETCore.App.Host.ubuntu.22.04-{ARCH}-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.NETCore.App.Host.ubuntu.22.04-{ARCH}-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-packs-runtime-host-rid
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/packs/Microsoft.NETCore.App.Host.ubuntu.22.04-{ARCH}/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/packs/Microsoft.NETCore.App.Host.ubuntu.22.04-{ARCH}/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.NETCore.App.Ref-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.NETCore.App.Ref-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-packs-runtime
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/packs/Microsoft.NETCore.App.Ref/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-sdk-{SDK_VERSION}.mount
+++ b/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-sdk-{SDK_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-sdk
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/sdk/{SDK_VERSION}
+Where=/var/snap/dotnet/common/dotnet/sdk/{SDK_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-sdk\x2dmanifests-6.0.100.mount
+++ b/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-sdk\x2dmanifests-6.0.100.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-sdk-manifests
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/sdk-manifests/6.0.100
+Where=/var/snap/dotnet/common/dotnet/sdk-manifests/6.0.100
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-templates-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-templates-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-templates
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/templates/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/templates/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-60/snapcraft.yaml
+++ b/dotnet-sdk-60/snapcraft.yaml
@@ -47,6 +47,45 @@ parts:
         craftctl set version="${DOTNET_SDK_VERSION}"
       fi
 
+  mounts:
+    plugin: dump
+    source: .
+    after:
+      - dotnet-sdk
+    override-build: |
+      RUNTIME_VERSION=$(ls ${CRAFT_STAGE}/usr/lib/dotnet/shared/Microsoft.NETCore.App/ | grep 6.0)
+      SDK_VERSION=$(ls ${CRAFT_STAGE}/usr/lib/dotnet/sdk | grep 6.0)
+      
+      if [ "${CRAFT_ARCH_BUILD_FOR}" = "amd64" ]; then
+        ARCH="x64"
+      elif [ "${CRAFT_ARCH_BUILD_FOR}" = "arm64" ]; then
+        ARCH="arm64"
+      else
+        echo "Unknown architecture (${CRAFT_ARCH_BUILD_FOR})"
+        exit 1
+      fi
+      
+      for file in mounts/*; do
+        sed -i "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/g" $file
+        sed -i "s/{SDK_VERSION}/$SDK_VERSION/g" $file
+        sed -i "s/{SNAP}/$CRAFT_PROJECT_NAME/g" $file
+        sed -i "s/{ARCH}/$ARCH/g" $file
+
+        new_file_name="$(echo "$file" \
+          | sed "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/" \
+          | sed "s/{SDK_VERSION}/$SDK_VERSION/" \
+          | sed "s/{ARCH}/$ARCH/")"
+
+        if [[ "$file" != "$new_file_name" ]]; then  
+          mv "$file" "$new_file_name"
+          echo "Renamed '$file' to '$new_file_name'"
+        fi
+      done
+
+      craftctl default
+    prime:
+      - mounts/
+
 lint:
   ignore:
     - library:

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-metadata-workloads-8.0.100.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-metadata-workloads-8.0.100.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-metadata
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/metadata/workloads/8.0.100
+Where=/var/snap/dotnet/common/dotnet/metadata/workloads/8.0.100
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.AspNetCore.App.Ref-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.AspNetCore.App.Ref-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-packs-aspnetcore
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/packs/Microsoft.AspNetCore.App.Ref/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/packs/Microsoft.AspNetCore.App.Ref/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.AspNetCore.App.Runtime.ubuntu.22.04-{ARCH}-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.AspNetCore.App.Runtime.ubuntu.22.04-{ARCH}-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-packs-aspnetcore-runtime-rid
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/packs/Microsoft.AspNetCore.App.Runtime.ubuntu.22.04-{ARCH}/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/packs/Microsoft.AspNetCore.App.Runtime.ubuntu.22.04-{ARCH}/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.NETCore.App.Host.ubuntu.22.04-{ARCH}-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.NETCore.App.Host.ubuntu.22.04-{ARCH}-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-packs-runtime-host-rid
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/packs/Microsoft.NETCore.App.Host.ubuntu.22.04-{ARCH}/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/packs/Microsoft.NETCore.App.Host.ubuntu.22.04-{ARCH}/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.NETCore.App.Ref-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.NETCore.App.Ref-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-packs-runtime
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/packs/Microsoft.NETCore.App.Ref/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.NETCore.App.Runtime.ubuntu.22.04-{ARCH}-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-packs-Microsoft.NETCore.App.Runtime.ubuntu.22.04-{ARCH}-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-packs-runtime-rid
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/packs/Microsoft.NETCore.App.Runtime.ubuntu.22.04-{ARCH}/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/packs/Microsoft.NETCore.App.Runtime.ubuntu.22.04-{ARCH}/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-sdk-{SDK_VERSION}.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-sdk-{SDK_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-sdk
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/sdk/{SDK_VERSION}
+Where=/var/snap/dotnet/common/dotnet/sdk/{SDK_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-sdk\x2dmanifests-8.0.100.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-sdk\x2dmanifests-8.0.100.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-sdk-manifests
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/sdk-manifests/8.0.100
+Where=/var/snap/dotnet/common/dotnet/sdk-manifests/8.0.100
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-templates-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-templates-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-templates
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/templates/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/templates/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/snapcraft.yaml
+++ b/dotnet-sdk-80/snapcraft.yaml
@@ -47,6 +47,45 @@ parts:
         craftctl set version="${DOTNET_SDK_VERSION}"
       fi
 
+  mounts:
+    plugin: dump
+    source: .
+    after:
+      - dotnet-sdk
+    override-build: |
+      RUNTIME_VERSION=$(ls ${CRAFT_STAGE}/usr/lib/dotnet/shared/Microsoft.NETCore.App/ | grep 8.0)
+      SDK_VERSION=$(ls ${CRAFT_STAGE}/usr/lib/dotnet/sdk | grep 8.0)
+      
+      if [ "${CRAFT_ARCH_BUILD_FOR}" = "amd64" ]; then
+        ARCH="x64"
+      elif [ "${CRAFT_ARCH_BUILD_FOR}" = "arm64" ]; then
+        ARCH="arm64"
+      else
+        echo "Unknown architecture (${CRAFT_ARCH_BUILD_FOR})"
+        exit 1
+      fi
+
+      for file in mounts/*; do
+        sed -i "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/g" $file
+        sed -i "s/{SDK_VERSION}/$SDK_VERSION/g" $file
+        sed -i "s/{SNAP}/$CRAFT_PROJECT_NAME/g" $file
+        sed -i "s/{ARCH}/$ARCH/g" $file
+
+        new_file_name="$(echo "$file" \
+          | sed "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/" \
+          | sed "s/{SDK_VERSION}/$SDK_VERSION/" \
+          | sed "s/{ARCH}/$ARCH/")"
+
+        if [[ "$file" != "$new_file_name" ]]; then  
+          mv "$file" "$new_file_name"
+          echo "Renamed '$file' to '$new_file_name'"
+        fi
+      done
+
+      craftctl default
+    prime:
+      - mounts/
+
 lint:
   ignore:
     - library:


### PR DESCRIPTION
- Update the .NET 6 and 8 Runtime and SDK content snaps to their latest July release.
- Bring the .NET 7 Runtime content snap to its latest release before end-of-life.
- Include the `systemd-mount` units to all snaps for easy integration with the new .NET Snap.
- Add the `workflow_dispatch` event to the GitHub Actions pipelines to allow for manual build/deploy triggering for updates that don't involve changing code and doing PRs.