### PR TITLE
Add test step to GitHub Actions workflows

### DIFF
--- a/.github/workflows/aspnetcore-runtime-60.yaml
+++ b/.github/workflows/aspnetcore-runtime-60.yaml
@@ -38,9 +38,38 @@ jobs:
         name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
         path: ${{ steps.build.outputs.snap }}
 
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+        id: checkout
+      - id: get-arch
+        run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
+      - name: Install snap
+        id: install-snap
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          sudo snap install --dangerous --devmode $SNAP_FILE_NAME
+      - name: Verify .mount units
+        id: verify-mounts
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current/usr/lib/dotnet
+
   publish:
     runs-on: ubuntu-latest
-    needs: build
+    needs: test
     if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref_name == 'main' }}
     strategy:
       matrix:

--- a/.github/workflows/aspnetcore-runtime-80.yaml
+++ b/.github/workflows/aspnetcore-runtime-80.yaml
@@ -38,9 +38,38 @@ jobs:
         name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
         path: ${{ steps.build.outputs.snap }}
 
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+        id: checkout
+      - id: get-arch
+        run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
+      - name: Install snap
+        id: install-snap
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          sudo snap install --dangerous --devmode $SNAP_FILE_NAME
+      - name: Verify .mount units
+        id: verify-mounts
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current/usr/lib/dotnet
+
   publish:
     runs-on: ubuntu-latest
-    needs: build
+    needs: test
     if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref_name == 'main' }}
     strategy:
       matrix:

--- a/.github/workflows/dotnet-runtime-60.yaml
+++ b/.github/workflows/dotnet-runtime-60.yaml
@@ -28,9 +28,31 @@ jobs:
         name: ${{ env.SNAP_NAME }}
         path: ${{ steps.build.outputs.snap }}
 
-  publish:
+  test:
     runs-on: ubuntu-latest
     needs: build
+    steps:
+      - uses: actions/checkout@v4
+        id: checkout
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ env.SNAP_NAME }}
+      - name: Install snap
+        id: install-snap
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
+          sudo snap install --dangerous --devmode $SNAP_FILE_NAME_X64
+      - name: Verify .mount units
+        id: verify-mounts
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
     if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/dotnet-runtime-70.yaml
+++ b/.github/workflows/dotnet-runtime-70.yaml
@@ -28,9 +28,31 @@ jobs:
         name: ${{ env.SNAP_NAME }}
         path: ${{ steps.build.outputs.snap }}
 
-  publish:
+  test:
     runs-on: ubuntu-latest
     needs: build
+    steps:
+      - uses: actions/checkout@v4
+        id: checkout
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ env.SNAP_NAME }}
+      - name: Install snap
+        id: install-snap
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
+          sudo snap install --dangerous --devmode $SNAP_FILE_NAME_X64
+      - name: Verify .mount units
+        id: verify-mounts
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
     if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/dotnet-runtime-80.yaml
+++ b/.github/workflows/dotnet-runtime-80.yaml
@@ -28,9 +28,31 @@ jobs:
         name: ${{ env.SNAP_NAME }}
         path: ${{ steps.build.outputs.snap }}
 
-  publish:
+  test:
     runs-on: ubuntu-latest
     needs: build
+    steps:
+      - uses: actions/checkout@v4
+        id: checkout
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ env.SNAP_NAME }}
+      - name: Install snap
+        id: install-snap
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
+          sudo snap install --dangerous --devmode $SNAP_FILE_NAME_X64
+      - name: Verify .mount units
+        id: verify-mounts
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
     if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/dotnet-sdk-60.yaml
+++ b/.github/workflows/dotnet-sdk-60.yaml
@@ -36,9 +36,38 @@ jobs:
         name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
         path: ${{ steps.build.outputs.snap }}
 
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+        id: checkout
+      - id: get-arch
+        run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
+      - name: Install snap
+        id: install-snap
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          sudo snap install --dangerous --devmode $SNAP_FILE_NAME
+      - name: Verify .mount units
+        id: verify-mounts
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current/usr/lib/dotnet
+
   publish:
     runs-on: ubuntu-latest
-    needs: build
+    needs: test
     if: ${{ github.event_name == 'push' }}
     strategy:
       matrix:

--- a/.github/workflows/dotnet-sdk-80.yaml
+++ b/.github/workflows/dotnet-sdk-80.yaml
@@ -36,9 +36,38 @@ jobs:
         name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
         path: ${{ steps.build.outputs.snap }}
 
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+        id: checkout
+      - id: get-arch
+        run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@v4
+        id: download-artifact
+        with:
+          name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
+      - name: Install snap
+        id: install-snap
+        env:
+          ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          ls -la $ARTIFACT_PATH
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          sudo snap install --dangerous --devmode $SNAP_FILE_NAME
+      - name: Verify .mount units
+        id: verify-mounts
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current/usr/lib/dotnet
+
   publish:
     runs-on: ubuntu-latest
-    needs: build
+    needs: test
     if: ${{ github.event_name == 'push' }}
     strategy:
       matrix:

--- a/eng/test-mounts.sh
+++ b/eng/test-mounts.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+IFS=$'\n\t'
+
+# We take the snap name as an input parameter
+snap="$1"
+dotnet_path="$2"
+content_snap_path="/snap/$snap/current"
+
+# Test .NET output
+"$dotnet_path"/dotnet --info
+
+echo "Installing .mount units..."
+cp "$content_snap_path"/mounts/* /usr/lib/systemd/system
+systemctl daemon-reload
+
+for unit_path in "$content_snap_path"/mounts/*.mount; do
+    # Remove the preceding path from the unit name
+    unit=$(basename "$unit_path")
+
+    echo "Starting $unit..."
+    systemctl start "$unit"
+    systemctl status "$unit"
+
+    echo "Checking if mount exists..."
+    # We are deriving the path from the unit name because the name
+    # is the path itself escaped according to systemd-escape(1).
+    escaped_path="/$(basename --suffix=.mount "$unit")"
+    unescaped_path=$(systemd-escape --unescape "$escaped_path")
+
+    [[ -d $unescaped_path ]] && echo "Directory $unescaped_path exists"
+    [[ $(find "$unescaped_path" -maxdepth 1 | wc --lines) -gt 1 ]] && echo "Directory $unescaped_path is not empty"
+done


### PR DESCRIPTION
This PR adds a `test` step to all workflows.

The `test` step will install the content snap and the mount units that come with it, then it will check whether the mounts worked by going into the destination directory and checking if it exists and if it is non-empty.

Closes #6 