### PR TITLE
.NET content snaps mounting standalone directory hive

### DIFF
--- a/aspnetcore-runtime-60/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
+++ b/aspnetcore-runtime-60/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-shared
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/aspnetcore-runtime-80/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
+++ b/aspnetcore-runtime-80/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-shared
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.AspNetCore.App-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.AspNetCore.App-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-shared
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/shared/Microsoft.AspNetCore.App/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.AspNetCore.App/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-60/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-shared
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.AspNetCore.App-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.AspNetCore.App-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-shared
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/shared/Microsoft.AspNetCore.App/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.AspNetCore.App/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
+++ b/dotnet-sdk-80/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description={SNAP}-shared
+
+[Mount]
+What=/snap/{SNAP}/current/usr/lib/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/eng/test-mounts.sh
+++ b/eng/test-mounts.sh
@@ -6,9 +6,7 @@ IFS=$'\n\t'
 snap="$1"
 dotnet_path="$2"
 content_snap_path="/snap/$snap/current"
-
-# Test .NET output
-"$dotnet_path"/dotnet --info
+mount_destination_path="/var/snap/dotnet/common/dotnet"
 
 echo "Installing .mount units..."
 cp "$content_snap_path"/mounts/* /usr/lib/systemd/system
@@ -31,3 +29,9 @@ for unit_path in "$content_snap_path"/mounts/*.mount; do
     [[ -d $unescaped_path ]] && echo "Directory $unescaped_path exists"
     [[ $(find "$unescaped_path" -maxdepth 1 | wc --lines) -gt 1 ]] && echo "Directory $unescaped_path is not empty"
 done
+
+# Test .NET output
+cp --dereference --preserve=mode,ownership,timestamps "$dotnet_path"/dotnet "$mount_destination_path"
+cp --recursive --dereference --preserve=mode,ownership,timestamps "$dotnet_path"/host "$mount_destination_path"
+
+"$mount_destination_path"/dotnet --info


### PR DESCRIPTION
This PR adds extra .mount unit files to content snaps that have dependencies on other .NET components. These units will mount the dependency directories so that each content snap is standalone. E.g. the .NET SDK depends on the .NET runtime and the ASP.NET Core runtime, so the .NET SDK content snap will include .mount units to mount the SDK directories, as well as directories for both runtimes.

Since a mounted content snap is now standalone, the `test-mounts.sh` script has also been updated to mount the content snap first, then run `dotnet --info` on it to test the .NET installation.