### PR TITLE
.NET August updates

### DIFF
--- a/.github/workflows/aspnetcore-runtime-60.yaml
+++ b/.github/workflows/aspnetcore-runtime-60.yaml
@@ -94,4 +94,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
           snap: ${{ steps.gather-filename.outputs.SNAP_PATH }}
-          release: stable
+          release: candidate

--- a/.github/workflows/aspnetcore-runtime-60.yaml
+++ b/.github/workflows/aspnetcore-runtime-60.yaml
@@ -65,7 +65,7 @@ jobs:
           sudo snap install --dangerous --devmode $SNAP_FILE_NAME
       - name: Verify .mount units
         id: verify-mounts
-        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current/usr/lib/dotnet
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME"
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/aspnetcore-runtime-80.yaml
+++ b/.github/workflows/aspnetcore-runtime-80.yaml
@@ -94,4 +94,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
           snap: ${{ steps.gather-filename.outputs.SNAP_PATH }}
-          release: stable
+          release: candidate

--- a/.github/workflows/aspnetcore-runtime-80.yaml
+++ b/.github/workflows/aspnetcore-runtime-80.yaml
@@ -65,7 +65,7 @@ jobs:
           sudo snap install --dangerous --devmode $SNAP_FILE_NAME
       - name: Verify .mount units
         id: verify-mounts
-        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current/usr/lib/dotnet
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME"
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-runtime-60.yaml
+++ b/.github/workflows/dotnet-runtime-60.yaml
@@ -65,7 +65,7 @@ jobs:
           sudo snap install --dangerous --devmode $SNAP_FILE_NAME
       - name: Verify .mount units
         id: verify-mounts
-        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME"
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-runtime-60.yaml
+++ b/.github/workflows/dotnet-runtime-60.yaml
@@ -14,38 +14,55 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
       id: checkout
+    - id: prepare-sha
+      run: git show -s --format=%h > ${SNAP_NAME}/GIT_SHA
     - uses: snapcore/action-build@v1
       id: build
       with:
         path: ${{ env.SNAP_NAME }}
+    - id: get-arch
+      run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@v4
       id: upload-artifact
       with:
-        name: ${{ env.SNAP_NAME }}
+        # e.g. dotnet-runtime-60-amd64
+        name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
         path: ${{ steps.build.outputs.snap }}
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: build
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
     steps:
       - uses: actions/checkout@v4
         id: checkout
+      - id: get-arch
+        run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
       - uses: actions/download-artifact@v4
         id: download-artifact
         with:
-          name: ${{ env.SNAP_NAME }}
+          name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
       - name: Install snap
         id: install-snap
         env:
           ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
         run: |
           ls -la $ARTIFACT_PATH
-          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
-          sudo snap install --dangerous --devmode $SNAP_FILE_NAME_X64
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          sudo snap install --dangerous --devmode $SNAP_FILE_NAME
       - name: Verify .mount units
         id: verify-mounts
         run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current
@@ -53,23 +70,28 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref_name == 'main' }}
+    strategy:
+      matrix:
+        artifact-name:
+          - dotnet-runtime-60-amd64
+          - dotnet-runtime-60-arm64
     steps:
       - uses: actions/download-artifact@v4
         id: download-artifact
         with:
-          name: ${{ env.SNAP_NAME }}
+          name: ${{ matrix.artifact-name }}
       - name: Gather filename
         id: gather-filename
         env:
           ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
         run: |
           ls -la $ARTIFACT_PATH
-          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
-          echo "SNAP_PATH_X64=${SNAP_FILE_NAME_X64}" >> "$GITHUB_OUTPUT"
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          echo "SNAP_PATH=${SNAP_FILE_NAME}" >> "$GITHUB_OUTPUT"
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
-          snap: ${{ steps.gather-filename.outputs.SNAP_PATH_X64 }}
-          release: edge
+          snap: ${{ steps.gather-filename.outputs.SNAP_PATH }}
+          release: candidate

--- a/.github/workflows/dotnet-runtime-70.yaml
+++ b/.github/workflows/dotnet-runtime-70.yaml
@@ -65,7 +65,7 @@ jobs:
           sudo snap install --dangerous --devmode $SNAP_FILE_NAME
       - name: Verify .mount units
         id: verify-mounts
-        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME"
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-runtime-70.yaml
+++ b/.github/workflows/dotnet-runtime-70.yaml
@@ -14,38 +14,55 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
       id: checkout
+    - id: prepare-sha
+      run: git show -s --format=%h > ${SNAP_NAME}/GIT_SHA
     - uses: snapcore/action-build@v1
       id: build
       with:
         path: ${{ env.SNAP_NAME }}
+    - id: get-arch
+      run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@v4
       id: upload-artifact
       with:
-        name: ${{ env.SNAP_NAME }}
+        # e.g. dotnet-runtime-70-amd64
+        name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
         path: ${{ steps.build.outputs.snap }}
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: build
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
     steps:
       - uses: actions/checkout@v4
         id: checkout
+      - id: get-arch
+        run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
       - uses: actions/download-artifact@v4
         id: download-artifact
         with:
-          name: ${{ env.SNAP_NAME }}
+          name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
       - name: Install snap
         id: install-snap
         env:
           ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
         run: |
           ls -la $ARTIFACT_PATH
-          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
-          sudo snap install --dangerous --devmode $SNAP_FILE_NAME_X64
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          sudo snap install --dangerous --devmode $SNAP_FILE_NAME
       - name: Verify .mount units
         id: verify-mounts
         run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current
@@ -53,23 +70,28 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref_name == 'main' }}
+    strategy:
+      matrix:
+        artifact-name:
+          - dotnet-runtime-70-amd64
+          - dotnet-runtime-70-arm64
     steps:
       - uses: actions/download-artifact@v4
         id: download-artifact
         with:
-          name: ${{ env.SNAP_NAME }}
+          name: ${{ matrix.artifact-name }}
       - name: Gather filename
         id: gather-filename
         env:
           ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
         run: |
           ls -la $ARTIFACT_PATH
-          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
-          echo "SNAP_PATH_X64=${SNAP_FILE_NAME_X64}" >> "$GITHUB_OUTPUT"
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          echo "SNAP_PATH=${SNAP_FILE_NAME}" >> "$GITHUB_OUTPUT"
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
-          snap: ${{ steps.gather-filename.outputs.SNAP_PATH_X64 }}
-          release: edge
+          snap: ${{ steps.gather-filename.outputs.SNAP_PATH }}
+          release: candidate

--- a/.github/workflows/dotnet-runtime-80.yaml
+++ b/.github/workflows/dotnet-runtime-80.yaml
@@ -65,7 +65,7 @@ jobs:
           sudo snap install --dangerous --devmode $SNAP_FILE_NAME
       - name: Verify .mount units
         id: verify-mounts
-        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME"
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-runtime-80.yaml
+++ b/.github/workflows/dotnet-runtime-80.yaml
@@ -14,38 +14,55 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
       id: checkout
+    - id: prepare-sha
+      run: git show -s --format=%h > ${SNAP_NAME}/GIT_SHA
     - uses: snapcore/action-build@v1
       id: build
       with:
         path: ${{ env.SNAP_NAME }}
+    - id: get-arch
+      run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@v4
       id: upload-artifact
       with:
-        name: ${{ env.SNAP_NAME }}
+        # e.g. dotnet-runtime-80-amd64
+        name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
         path: ${{ steps.build.outputs.snap }}
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: build
+    strategy:
+      matrix:
+        os:
+          - [self-hosted, large, jammy, X64]
+          - [self-hosted, large, jammy, ARM64]
     steps:
       - uses: actions/checkout@v4
         id: checkout
+      - id: get-arch
+        run: echo "DPKG_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
       - uses: actions/download-artifact@v4
         id: download-artifact
         with:
-          name: ${{ env.SNAP_NAME }}
+          name: ${{ env.SNAP_NAME }}-${{ steps.get-arch.outputs.DPKG_ARCH }}
       - name: Install snap
         id: install-snap
         env:
           ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
         run: |
           ls -la $ARTIFACT_PATH
-          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
-          sudo snap install --dangerous --devmode $SNAP_FILE_NAME_X64
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          sudo snap install --dangerous --devmode $SNAP_FILE_NAME
       - name: Verify .mount units
         id: verify-mounts
         run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current
@@ -53,23 +70,28 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref_name == 'main' }}
+    strategy:
+      matrix:
+        artifact-name:
+          - dotnet-runtime-80-amd64
+          - dotnet-runtime-80-arm64
     steps:
       - uses: actions/download-artifact@v4
         id: download-artifact
         with:
-          name: ${{ env.SNAP_NAME }}
+          name: ${{ matrix.artifact-name }}
       - name: Gather filename
         id: gather-filename
         env:
           ARTIFACT_PATH: ${{ steps.download-artifact.outputs.download-path }}
         run: |
           ls -la $ARTIFACT_PATH
-          SNAP_FILE_NAME_X64=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*amd64.snap)
-          echo "SNAP_PATH_X64=${SNAP_FILE_NAME_X64}" >> "$GITHUB_OUTPUT"
+          SNAP_FILE_NAME=$(ls ${ARTIFACT_PATH}/${SNAP_NAME}*.snap)
+          echo "SNAP_PATH=${SNAP_FILE_NAME}" >> "$GITHUB_OUTPUT"
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
-          snap: ${{ steps.gather-filename.outputs.SNAP_PATH_X64 }}
-          release: edge
+          snap: ${{ steps.gather-filename.outputs.SNAP_PATH }}
+          release: candidate

--- a/.github/workflows/dotnet-sdk-60.yaml
+++ b/.github/workflows/dotnet-sdk-60.yaml
@@ -63,7 +63,7 @@ jobs:
           sudo snap install --dangerous --devmode $SNAP_FILE_NAME
       - name: Verify .mount units
         id: verify-mounts
-        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current/usr/lib/dotnet
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME"
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-sdk-60.yaml
+++ b/.github/workflows/dotnet-sdk-60.yaml
@@ -92,4 +92,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
           snap: ${{ steps.gather-filename.outputs.SNAP_PATH }}
-          release: edge
+          release: candidate

--- a/.github/workflows/dotnet-sdk-80.yaml
+++ b/.github/workflows/dotnet-sdk-80.yaml
@@ -63,7 +63,7 @@ jobs:
           sudo snap install --dangerous --devmode $SNAP_FILE_NAME
       - name: Verify .mount units
         id: verify-mounts
-        run: sudo ./eng/test-mounts.sh "$SNAP_NAME" /snap/"$SNAP_NAME"/current/usr/lib/dotnet
+        run: sudo ./eng/test-mounts.sh "$SNAP_NAME"
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-sdk-80.yaml
+++ b/.github/workflows/dotnet-sdk-80.yaml
@@ -92,4 +92,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:
           snap: ${{ steps.gather-filename.outputs.SNAP_PATH }}
-          release: edge
+          release: candidate

--- a/aspnetcore-runtime-60/snap/snapcraft.yaml
+++ b/aspnetcore-runtime-60/snap/snapcraft.yaml
@@ -9,6 +9,11 @@ description: |
 grade: stable
 confinement: strict
 
+package-repositories:
+ - type: apt
+   ppa: dotnet/snaps
+   priority: always
+
 architectures:
   - build-on: [amd64]
     build-for: [amd64]

--- a/aspnetcore-runtime-80/snap/snapcraft.yaml
+++ b/aspnetcore-runtime-80/snap/snapcraft.yaml
@@ -9,6 +9,11 @@ description: |
 grade: stable
 confinement: strict
 
+package-repositories:
+ - type: apt
+   ppa: dotnet/snaps
+   priority: always
+
 architectures:
   - build-on: [amd64]
     build-for: [amd64]

--- a/dotnet-runtime-60/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
+++ b/dotnet-runtime-60/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
@@ -2,7 +2,7 @@
 Description={SNAP}-shared
 
 [Mount]
-What=/snap/{SNAP}/current/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+What=/snap/{SNAP}/current/usr/lib/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
 Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
 Type=none
 Options=bind

--- a/dotnet-runtime-60/snap/snapcraft.yaml
+++ b/dotnet-runtime-60/snap/snapcraft.yaml
@@ -9,6 +9,11 @@ description: |
 grade: stable
 confinement: strict
 
+package-repositories:
+ - type: apt
+   ppa: dotnet/snaps
+   priority: always
+
 apps:
   dotnet:
     command: dotnet

--- a/dotnet-runtime-60/snap/snapcraft.yaml
+++ b/dotnet-runtime-60/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: dotnet-runtime-60
-base: core20
-version: 6.0.32
-summary: Cross-Platform .NET Core Runtime.
+base: core22
+adopt-info: dotnet-runtime
+summary: .NET Core 6.0 Runtime.
 description: |
   .NET Core runtimes and libraries which are optimized for running .NET Core apps in production. See https://dot.net/core.
   .NET Core is a general purpose development platform maintained by Microsoft.
@@ -18,28 +18,61 @@ apps:
       - removable-media
       - home
 
+architectures:
+  - build-on: [amd64]
+    build-for: [amd64]
+  - build-on: [arm64]
+    build-for: [arm64]
+
 slots:
   dotnet-runtime:
     content: dotnet-runtime-60
     interface: content
-    read: [/]
+    source:
+      read:
+        - $SNAP/usr/lib/dotnet
 
 parts:
   dotnet-runtime:
-    plugin: dump
-    source: https://download.visualstudio.microsoft.com/download/pr/37d9269f-d651-4248-beae-ccfbf4dc34fc/17809ba306015df6406cf4338b5cc576/dotnet-runtime-6.0.32-linux-x64.tar.gz
-    source-checksum: sha512/9babfe66f4a4261dd454f3220899af0a19532ab93575b581cec838f1c5f130d98b6fb1aaae5ee8e5b2e70deb55b619a0d55347f014ace72cb84b78d61faf0a59
+    plugin: nil
+    source: .
     stage-packages:
-      - libicu66
-      - liblttng-ust0
+      - dotnet-runtime-6.0
+    override-stage: |
+      craftctl default
+
+      if [ "${CRAFT_ARCH_BUILD_FOR}" = "amd64" ]; then
+        DOTNET_RUNTIME_VERSION=$(LD_LIBRARY_PATH=${CRAFT_STAGE}/usr/lib/x86_64-linux-gnu ${CRAFT_STAGE}/usr/lib/dotnet/dotnet --list-runtimes \
+          grep NETCoreApp | head -n 1 | awk '{print $2}')
+      elif [ "${CRAFT_ARCH_BUILD_FOR}" = "arm64" ]; then
+        DOTNET_RUNTIME_VERSION=$(LD_LIBRARY_PATH=${CRAFT_STAGE}/usr/lib/aarch64-linux-gnu ${CRAFT_STAGE}/usr/lib/dotnet/dotnet --list-runtimes \
+          grep NETCoreApp | head -n 1 | awk '{print $2}')
+      else
+        echo "Unknown architecture (${CRAFT_ARCH_BUILD_FOR})"
+        exit 1
+      fi
+
+      if [ -f ${CRAFT_PART_SRC}/GIT_SHA ]; then
+        craftctl set version="${DOTNET_RUNTIME_VERSION}+git.$(cat ${CRAFT_PART_SRC}/GIT_SHA)"
+      else
+        craftctl set version="${DOTNET_RUNTIME_VERSION}"
+      fi
+    override-prime: |
+      # This is for backwards compatibility:
+      # Up until now, .NET Runtime content snaps would place the .NET directory hive
+      # in /. As the binaries are now pulled from Canonical's deb package, which installs
+      # the hive into /usr/lib/dotnet, we place a `dotnet` symlink in / so that it's
+      # still where people might expect it to be.
+      ln --symbolic usr/lib/dotnet/dotnet "${CRAFT_PRIME}"/dotnet
+      craftctl default
   
   mounts:
     plugin: dump
+    source: .
     after: 
       - dotnet-runtime
-    source: .
     override-build: |
-      RUNTIME_VERSION=$(ls ${SNAPCRAFT_STAGE}/shared/Microsoft.NETCore.App/ | grep 6.0)
+      RUNTIME_VERSION=$(ls ${SNAPCRAFT_STAGE}/usr/lib/dotnet/shared/Microsoft.NETCore.App/ | grep 6.0)
       
       for file in mounts/*; do
         sed -i "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/g" $file
@@ -51,4 +84,13 @@ parts:
         fi
       done
 
-      snapcraftctl build
+      craftctl default
+    prime:
+      - mounts/
+
+lint:
+  ignore:
+    - library:
+      - usr/lib/**/libicu*
+      - usr/lib/**/liblttng-ust-*
+      - usr/lib/**/libunwind-*

--- a/dotnet-runtime-70/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
+++ b/dotnet-runtime-70/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
@@ -2,7 +2,7 @@
 Description={SNAP}-shared
 
 [Mount]
-What=/snap/{SNAP}/current/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+What=/snap/{SNAP}/current/usr/lib/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
 Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
 Type=none
 Options=bind

--- a/dotnet-runtime-70/snap/snapcraft.yaml
+++ b/dotnet-runtime-70/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: dotnet-runtime-70
-base: core20
-version: 7.0.20
-summary: Cross-Platform .NET Core Runtime.
+base: core22
+adopt-info: dotnet-runtime
+summary: .NET Core 7.0 Runtime.
 description: |
   .NET Core runtimes and libraries which are optimized for running .NET Core apps in production. See https://dot.net/core.
   .NET Core is a general purpose development platform maintained by Microsoft.
@@ -18,28 +18,61 @@ apps:
       - removable-media
       - home
 
+architectures:
+  - build-on: [amd64]
+    build-for: [amd64]
+  - build-on: [arm64]
+    build-for: [arm64]
+
 slots:
   dotnet-runtime:
     content: dotnet-runtime-70
     interface: content
-    read: [/]
+    source:
+      read:
+        - $SNAP/usr/lib/dotnet
 
 parts:
   dotnet-runtime:
-    plugin: dump
-    source: https://download.visualstudio.microsoft.com/download/pr/2c5981ff-0f0c-47ab-bff4-0ea4919b395b/cbfdfa7f35d133b0bdef87fa3830bfa0/dotnet-runtime-7.0.20-linux-x64.tar.gz
-    source-checksum: sha512/87855297338555a7b577d7e314e5dbf2c2350f8c867a489cd1e535634bad5c123a1871464d37fc9421837ff5d426c2eadecbe0f60bbf3fd32bc2461f47790a40
+    plugin: nil
+    source: .
     stage-packages:
-      - libicu66
-      - liblttng-ust0
+      - dotnet-runtime-7.0
+    override-stage: |
+      craftctl default
+
+      if [ "${CRAFT_ARCH_BUILD_FOR}" = "amd64" ]; then
+        DOTNET_RUNTIME_VERSION=$(LD_LIBRARY_PATH=${CRAFT_STAGE}/usr/lib/x86_64-linux-gnu ${CRAFT_STAGE}/usr/lib/dotnet/dotnet --list-runtimes \
+          grep NETCoreApp | head -n 1 | awk '{print $2}')
+      elif [ "${CRAFT_ARCH_BUILD_FOR}" = "arm64" ]; then
+        DOTNET_RUNTIME_VERSION=$(LD_LIBRARY_PATH=${CRAFT_STAGE}/usr/lib/aarch64-linux-gnu ${CRAFT_STAGE}/usr/lib/dotnet/dotnet --list-runtimes \
+          grep NETCoreApp | head -n 1 | awk '{print $2}')
+      else
+        echo "Unknown architecture (${CRAFT_ARCH_BUILD_FOR})"
+        exit 1
+      fi
+
+      if [ -f ${CRAFT_PART_SRC}/GIT_SHA ]; then
+        craftctl set version="${DOTNET_RUNTIME_VERSION}+git.$(cat ${CRAFT_PART_SRC}/GIT_SHA)"
+      else
+        craftctl set version="${DOTNET_RUNTIME_VERSION}"
+      fi
+    override-prime: |
+      # This is for backwards compatibility:
+      # Up until now, .NET Runtime content snaps would place the .NET directory hive
+      # in /. As the binaries are now pulled from Canonical's deb package, which installs
+      # the hive into /usr/lib/dotnet, we place a `dotnet` symlink in / so that it's
+      # still where people might expect it to be.
+      ln --symbolic usr/lib/dotnet/dotnet "${CRAFT_PRIME}"/dotnet
+      craftctl default
 
   mounts:
     plugin: dump
+    source: .
     after: 
       - dotnet-runtime
-    source: .
     override-build: |
-      RUNTIME_VERSION=$(ls ${SNAPCRAFT_STAGE}/shared/Microsoft.NETCore.App/ | grep 7.0)
+      RUNTIME_VERSION=$(ls ${SNAPCRAFT_STAGE}/usr/lib/dotnet/shared/Microsoft.NETCore.App/ | grep 7.0)
       
       for file in mounts/*; do
         sed -i "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/g" $file
@@ -51,4 +84,13 @@ parts:
         fi
       done
 
-      snapcraftctl build
+      craftctl default
+    prime:
+      - mounts/
+
+lint:
+  ignore:
+    - library:
+      - usr/lib/**/libicu*
+      - usr/lib/**/liblttng-ust-*
+      - usr/lib/**/libunwind-*

--- a/dotnet-runtime-70/snap/snapcraft.yaml
+++ b/dotnet-runtime-70/snap/snapcraft.yaml
@@ -9,6 +9,11 @@ description: |
 grade: stable
 confinement: strict
 
+package-repositories:
+ - type: apt
+   ppa: dotnet/snaps
+   priority: always
+
 apps:
   dotnet:
     command: dotnet

--- a/dotnet-runtime-80/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
+++ b/dotnet-runtime-80/mounts/var-snap-dotnet-common-dotnet-shared-Microsoft.NETCore.App-{RUNTIME_VERSION}.mount
@@ -2,7 +2,7 @@
 Description={SNAP}-shared
 
 [Mount]
-What=/snap/{SNAP}/current/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
+What=/snap/{SNAP}/current/usr/lib/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
 Where=/var/snap/dotnet/common/dotnet/shared/Microsoft.NETCore.App/{RUNTIME_VERSION}
 Type=none
 Options=bind

--- a/dotnet-runtime-80/snap/snapcraft.yaml
+++ b/dotnet-runtime-80/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: dotnet-runtime-80
-base: core20
-version: 8.0.7
-summary: Cross-Platform .NET Core Runtime.
+base: core22
+adopt-info: dotnet-runtime
+summary: .NET Core 8.0 Runtime.
 description: |
   .NET Core runtimes and libraries which are optimized for running .NET Core apps in production. See https://dot.net/core.
   .NET Core is a general purpose development platform maintained by Microsoft.
@@ -18,28 +18,61 @@ apps:
       - removable-media
       - home
 
+architectures:
+  - build-on: [amd64]
+    build-for: [amd64]
+  - build-on: [arm64]
+    build-for: [arm64]
+
 slots:
   dotnet-runtime:
     content: dotnet-runtime-80
     interface: content
-    read: [/]
+    source:
+      read:
+        - $SNAP/usr/lib/dotnet
 
 parts:
   dotnet-runtime:
-    plugin: dump
-    source: https://download.visualstudio.microsoft.com/download/pr/cf3418ca-0e14-4b76-b615-ac2f2497f8ec/2583028ea52460cb1534d929dc7970fe/dotnet-runtime-8.0.7-linux-x64.tar.gz
-    source-checksum: sha512/88e9ac34ad5ac76eec5499f2eb8d1aa35076518c842854ec1053953d34969c7bf1c5b2dbce245dbace3a18c3b8a4c79d2ef2d2ff105ce9d17cbbdbe813d8b16f
+    plugin: nil
+    source: .
     stage-packages:
-      - libicu66
-      - liblttng-ust0
+      - dotnet-runtime-8.0
+    override-stage: |
+      craftctl default
+
+      if [ "${CRAFT_ARCH_BUILD_FOR}" = "amd64" ]; then
+        DOTNET_RUNTIME_VERSION=$(LD_LIBRARY_PATH=${CRAFT_STAGE}/usr/lib/x86_64-linux-gnu ${CRAFT_STAGE}/usr/lib/dotnet/dotnet --list-runtimes \
+          grep NETCoreApp | head -n 1 | awk '{print $2}')
+      elif [ "${CRAFT_ARCH_BUILD_FOR}" = "arm64" ]; then
+        DOTNET_RUNTIME_VERSION=$(LD_LIBRARY_PATH=${CRAFT_STAGE}/usr/lib/aarch64-linux-gnu ${CRAFT_STAGE}/usr/lib/dotnet/dotnet --list-runtimes \
+          grep NETCoreApp | head -n 1 | awk '{print $2}')
+      else
+        echo "Unknown architecture (${CRAFT_ARCH_BUILD_FOR})"
+        exit 1
+      fi
+
+      if [ -f ${CRAFT_PART_SRC}/GIT_SHA ]; then
+        craftctl set version="${DOTNET_RUNTIME_VERSION}+git.$(cat ${CRAFT_PART_SRC}/GIT_SHA)"
+      else
+        craftctl set version="${DOTNET_RUNTIME_VERSION}"
+      fi
+    override-prime: |
+      # This is for backwards compatibility:
+      # Up until now, .NET Runtime content snaps would place the .NET directory hive
+      # in /. As the binaries are now pulled from Canonical's deb package, which installs
+      # the hive into /usr/lib/dotnet, we place a `dotnet` symlink in / so that it's
+      # still where people might expect it to be.
+      ln --symbolic usr/lib/dotnet/dotnet "${CRAFT_PRIME}"/dotnet
+      craftctl default
 
   mounts:
     plugin: dump
+    source: .
     after: 
       - dotnet-runtime
-    source: .
     override-build: |
-      RUNTIME_VERSION=$(ls ${SNAPCRAFT_STAGE}/shared/Microsoft.NETCore.App/ | grep 8.0)
+      RUNTIME_VERSION=$(ls ${SNAPCRAFT_STAGE}/usr/lib/dotnet/shared/Microsoft.NETCore.App/ | grep 8.0)
       
       for file in mounts/*; do
         sed -i "s/{RUNTIME_VERSION}/$RUNTIME_VERSION/g" $file
@@ -51,4 +84,13 @@ parts:
         fi
       done
 
-      snapcraftctl build
+      craftctl default
+    prime:
+      - mounts/
+
+lint:
+  ignore:
+    - library:
+      - usr/lib/**/libicu*
+      - usr/lib/**/liblttng-ust-*
+      - usr/lib/**/libunwind-*

--- a/dotnet-runtime-80/snap/snapcraft.yaml
+++ b/dotnet-runtime-80/snap/snapcraft.yaml
@@ -9,6 +9,11 @@ description: |
 grade: stable
 confinement: strict
 
+package-repositories:
+ - type: apt
+   ppa: dotnet/snaps
+   priority: always
+
 apps:
   dotnet:
     command: dotnet

--- a/dotnet-sdk-60/snap/snapcraft.yaml
+++ b/dotnet-sdk-60/snap/snapcraft.yaml
@@ -9,6 +9,11 @@ description: |
 grade: stable
 confinement: strict
 
+package-repositories:
+ - type: apt
+   ppa: dotnet/snaps
+   priority: always
+
 architectures:
   - build-on: [amd64]
     build-for: [amd64]

--- a/dotnet-sdk-80/snap/snapcraft.yaml
+++ b/dotnet-sdk-80/snap/snapcraft.yaml
@@ -9,6 +9,11 @@ description: |
 grade: stable
 confinement: strict
 
+package-repositories:
+ - type: apt
+   ppa: dotnet/snaps
+   priority: always
+
 architectures:
   - build-on: [amd64]
     build-for: [amd64]

--- a/eng/test-mounts.sh
+++ b/eng/test-mounts.sh
@@ -4,8 +4,8 @@ IFS=$'\n\t'
 
 # We take the snap name as an input parameter
 snap="$1"
-dotnet_path="$2"
 content_snap_path="/snap/$snap/current"
+dotnet_path="${content_snap_path}/usr/lib/dotnet"
 mount_destination_path="/var/snap/dotnet/common/dotnet"
 
 echo "Installing .mount units..."


### PR DESCRIPTION
This PR releases the following .NET content snaps:

- .NET Runtime 6.0.33, 8.0.8
- ASP.NET Core Runtime 6.0.33, 8.0.8
- .NET SDK 6.0.133, 8.0.108

Also, it includes the following changes:

- The `dotnet-runtime-*0` content snaps now ship Canonical source-build runtime binaries, which now live under `$SNAP/usr/lib/dotnet`. For backwards compatibility, we've kept a `dotnet` symlink in `$SNAP/`. The mount units have been updated accordingly.
- The `dotnet-runtime-*.0` content snaps have also been updated from `core20` to `core22`.
- All the `snapcraft.yaml` files now point to `ppa:dotnet/snaps` as the source of deb packages, since that's where the deb packages for snaps will live from now on.
- Since all .NET binaries come from deb packages, the .NET root is now known to always be `$SNAP/usr/lib/dotnet`. For that reason, the second parameter of the `test-mounts.sh` script has been removed as it's no longer needed.