### PR TITLE
Add `workflow_dispatch` as a valid trigger to SDK publish jobs

### DIFF
--- a/.github/workflows/dotnet-sdk-60.yaml
+++ b/.github/workflows/dotnet-sdk-60.yaml
@@ -70,7 +70,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref_name == 'main' }}
     strategy:
       matrix:
         artifact-name:

--- a/.github/workflows/dotnet-sdk-80.yaml
+++ b/.github/workflows/dotnet-sdk-80.yaml
@@ -70,7 +70,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref_name == 'main' }}
     strategy:
       matrix:
         artifact-name:


### PR DESCRIPTION
Currently, the `dotnet-sdk-*` publish jobs only run if `github.event == 'push'`. Therefore, in the case that the workflow is triggered manually to build a given .NET release, the resulting snap won't get published as the `github.event` would effectively be `workflow_dispatch`.

This adds `workflow_dispatch` as a valid trigger for the `publish` jobs.