### PR TITLE
Individual tokens per .NET release

### DIFF
--- a/.github/workflows/dotnet-100.yaml
+++ b/.github/workflows/dotnet-100.yaml
@@ -37,4 +37,4 @@ jobs:
       publish-aspnetcore-runtime: true
       publish-dotnet-sdk: true
     secrets:
-      snap-store-token: ${{ secrets.SNAP_STORE_LOGIN }}
+      snap-store-token: ${{ secrets.DOTNET10_SNAP_STORE_LOGIN }}

--- a/.github/workflows/dotnet-60.yaml
+++ b/.github/workflows/dotnet-60.yaml
@@ -37,4 +37,4 @@ jobs:
       publish-aspnetcore-runtime: true
       publish-dotnet-sdk: true
     secrets:
-      snap-store-token: ${{ secrets.SNAP_STORE_LOGIN }}
+      snap-store-token: ${{ secrets.DOTNET6_SNAP_STORE_LOGIN }}

--- a/.github/workflows/dotnet-70.yaml
+++ b/.github/workflows/dotnet-70.yaml
@@ -35,4 +35,4 @@ jobs:
       publish-aspnetcore-runtime: false
       publish-dotnet-sdk: false
     secrets:
-      snap-store-token: ${{ secrets.SNAP_STORE_LOGIN }}
+      snap-store-token: ${{ secrets.DOTNET7_SNAP_STORE_LOGIN }}

--- a/.github/workflows/dotnet-80.yaml
+++ b/.github/workflows/dotnet-80.yaml
@@ -37,4 +37,4 @@ jobs:
       publish-aspnetcore-runtime: true
       publish-dotnet-sdk: true
     secrets:
-      snap-store-token: ${{ secrets.SNAP_STORE_LOGIN }}
+      snap-store-token: ${{ secrets.DOTNET8_SNAP_STORE_LOGIN }}

--- a/.github/workflows/dotnet-90.yaml
+++ b/.github/workflows/dotnet-90.yaml
@@ -37,4 +37,4 @@ jobs:
       publish-aspnetcore-runtime: true
       publish-dotnet-sdk: true
     secrets:
-      snap-store-token: ${{ secrets.SNAP_STORE_LOGIN }}
+      snap-store-token: ${{ secrets.DOTNET9_SNAP_STORE_LOGIN }}


### PR DESCRIPTION
Replace the single Snap Store token that provided access to all .NET releases with individual tokens per .NET major release.